### PR TITLE
Feature evaluator

### DIFF
--- a/lib/forth_evaluator/dictionary.ex
+++ b/lib/forth_evaluator/dictionary.ex
@@ -1,0 +1,84 @@
+defmodule ForthEvaluator.Dictionary do
+  alias ForthEvaluator.Parser
+
+  @moduledoc """
+  A dictionary stores program defined words and the tokens that they
+  represent during its execution.
+  """
+  use Agent
+
+  @spec start_link(initial_state :: map()) :: Agent.on_start()
+  @doc """
+  Starts a new Dictionary agent using the given map as its initial state.
+  The default is an empty dictionary.
+
+  ## Example
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link()
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{}
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link(%{"word" => []})
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{"word" => []}
+
+  """
+  def start_link(initial_state \\ %{}) do
+    Agent.start_link(fn -> initial_state end)
+  end
+
+  @spec stop(dictionary :: pid()) :: no_return()
+  @doc """
+  Stops the Dictionary process normally.
+  """
+  def stop(dictionary) do
+    Agent.stop(dictionary)
+  end
+
+  @spec store(dict :: pid(), word :: Parser.word(), tokens :: [Parser.token()]) :: no_return()
+  @doc """
+  Stores the given tokens under the given name into the dictionary.
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link()
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{}
+    iex> ForthEvaluator.Dictionary.store(dictionary, "word", [1, 2])
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{"word" => [1, 2]}
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link(%{"word1" => [1]})
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{"word1" => [1]}
+    iex> ForthEvaluator.Dictionary.store(dictionary, "word2", [2, 3])
+    iex> Agent.get(dictionary, &Function.identity/1)
+    %{"word1" => [1], "word2" => [2, 3]}
+
+  """
+  def store(dictionary, word, tokens) do
+    Agent.update(dictionary, fn state -> Map.put(state, word, tokens) end)
+  end
+
+  @spec search(dict :: pid(), word :: Parser.word()) :: [Parser.token()] | :unknown
+  @doc """
+  Retrieves the tokens stored under the given word.
+  If the word is not in the dictionary, returns the `:unknown` atom.
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link()
+    iex> ForthEvaluator.Dictionary.store(dictionary, "word", [1, 2])
+    iex> ForthEvaluator.Dictionary.search(dictionary, "word")
+    [1, 2]
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link(%{"word1" => [1]})
+    iex> ForthEvaluator.Dictionary.store(dictionary, "word2", [2, 3])
+    iex> ForthEvaluator.Dictionary.search(dictionary, "word2")
+    [2, 3]
+
+    iex> {:ok, dictionary} = ForthEvaluator.Dictionary.start_link()
+    iex> ForthEvaluator.Dictionary.search(dictionary, "unknown_word")
+    :unknown
+
+  """
+  def search(dictionary, word) do
+    Agent.get(dictionary, fn state -> Map.get(state, word, :unknown) end)
+  end
+end

--- a/lib/forth_evaluator/evaluator.ex
+++ b/lib/forth_evaluator/evaluator.ex
@@ -1,0 +1,66 @@
+defmodule ForthEvaluator.Evaluator do
+  alias ForthEvaluator.Stack
+  alias ForthEvaluator.Dictionary
+  alias ForthEvaluator.Parser
+
+  @spec evaluate(tokens :: [Parser.token()], stack :: pid(), dictionary :: pid()) :: String.t()
+  @doc """
+  Evaluates a list of tokens running each encapsulated operation sequentialy
+  using the provided stack and dictionary processes and returns the program's
+  output as a string.
+  """
+  def evaluate(tokens, stack, dictionary) do
+    tokens
+    |> execute_tokens(stack, dictionary)
+    # Compile results
+    |> List.flatten()
+    # Convert results to strings
+    |> Enum.map(&result_to_string/1)
+    # Remove empty strings
+    |> Enum.filter(&(&1 != ""))
+    # Produce output string
+    |> Enum.join(" ")
+  end
+
+  defp execute_tokens(tokens, stack, dictionary) do
+    Enum.reduce_while(tokens, [], fn token, results ->
+      result = evaluate_token(stack, dictionary, token)
+      results = results ++ [result]
+
+      case result do
+        {:error, _} -> {:halt, results}
+        _ -> {:cont, results}
+      end
+    end)
+  end
+
+  # Evaluates a single token executing the correspoing operation depending of
+  # the token type:
+  # - Stack operation (`:stack_op`)
+  # - Dictionary operation (`:dictionary_op`)
+  defp evaluate_token(stack, dictionary, token) do
+    case token do
+      {:stack_op, operation, args} ->
+        apply(Stack, operation, [stack | args])
+
+      {:dictionary_op, operation, args} ->
+        result = apply(Dictionary, operation, [dictionary | args])
+
+        if result == :unknown do
+          {:error, "Unknown word '#{List.first(args)}'"}
+        else
+          case operation do
+            :store -> {:ok, ""}
+            :search -> execute_tokens(result, stack, dictionary)
+          end
+        end
+    end
+  end
+
+  defp result_to_string(result) do
+    case result do
+      {:error, error_message} -> "RuntimeError: #{error_message}"
+      {:ok, return_value} -> to_string(return_value)
+    end
+  end
+end

--- a/lib/forth_evaluator/stack.ex
+++ b/lib/forth_evaluator/stack.ex
@@ -1,0 +1,394 @@
+defmodule ForthEvaluator.Stack do
+  @moduledoc """
+  A Stack stores a program's state during its execution.
+  """
+  use Agent
+
+  @type op_result :: {:ok, return_value :: String.t()} | {:error, error_msg :: String.t()}
+
+  @spec start_link(initial_state :: list()) :: Agent.on_start()
+  @doc """
+  Starts a new Stack agent using the given list as its initial state.
+  The default is an empty stack.
+
+  ## Example
+
+    iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+    iex> Agent.get(stack, &Function.identity/1)
+    []
+
+    iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1, 2, 3])
+    iex> Agent.get(stack, &Function.identity/1)
+    [1, 2, 3]
+
+  """
+  def start_link(initial_state \\ []) when is_list(initial_state) do
+    Agent.start_link(fn -> initial_state end)
+  end
+
+  @spec stop(stack :: pid()) :: no_return()
+  @doc """
+  Stops the Stack process normally.
+  """
+  def stop(stack) do
+    Agent.stop(stack)
+  end
+
+  @spec pop(stack :: pid()) :: op_result
+  @doc """
+  Pops the top of the stack.
+  If successful, returns the poped value as a string.
+  If the stack is empty, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1, 2])
+      iex> ForthEvaluator.Stack.pop(stack)
+      {:ok, "1"}
+      iex> ForthEvaluator.Stack.pop(stack)
+      {:ok, "2"}
+      iex> ForthEvaluator.Stack.pop(stack)
+      {:error, "The stack is empty."}
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.pop(stack)
+      {:error, "The stack is empty."}
+
+  """
+  def pop(stack) do
+    Agent.get_and_update(stack, fn state ->
+      case state do
+        [head | tail] -> success(tail, to_string(head))
+        _ -> failure(state, :single)
+      end
+    end)
+  end
+
+  @spec push(stack :: pid(), value :: number()) :: op_result
+  @doc """
+  Pushes a new element to the top of the stack and returns an 
+  empty string (meaning there is no return value for this operation).
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> Agent.get(stack, &Function.identity/1)
+      [] 
+      iex> ForthEvaluator.Stack.push(stack, 10)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [10] 
+      iex> ForthEvaluator.Stack.push(stack, 20)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [20, 10] 
+
+  """
+  def push(stack, value) do
+    Agent.update(stack, fn state -> [value | state] end)
+    {:ok, ""}
+  end
+
+  @spec add(stack :: pid()) :: op_result
+  @doc """
+  Adds the top two elements of the stack removing them from it and placing
+  the result at the top.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([2, 2])
+      iex> ForthEvaluator.Stack.add(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [4]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1])
+      iex> ForthEvaluator.Stack.add(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.add(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+  """
+  def add(stack) do
+    binary_operation(stack, &+/2)
+  end
+
+  @spec substract(stack :: pid()) :: op_result
+  @doc """
+  Substracts the top two elements of the stack removing them from it and placing
+  the result at the top.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3, 6])
+      iex> ForthEvaluator.Stack.substract(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [-3]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([100])
+      iex> ForthEvaluator.Stack.substract(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.substract(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+  """
+  def substract(stack) do
+    binary_operation(stack, &-/2)
+  end
+
+  @spec multiply(stack :: pid()) :: op_result
+  @doc """
+  Multiplies the top two elements of the stack removing them from it and placing
+  the result at the top.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([2, 3, 4])
+      iex> ForthEvaluator.Stack.multiply(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [6, 4]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([50])
+      iex> ForthEvaluator.Stack.multiply(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.multiply(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+  """
+  def multiply(stack) do
+    binary_operation(stack, &*/2)
+  end
+
+  @spec divide(stack :: pid()) :: op_result
+  @doc """
+  Divides the top two elements of the stack removing them from it and placing
+  the result at the top.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+  If the second element is 0, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([40, 2, 1, 2, 3])
+      iex> ForthEvaluator.Stack.divide(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [20.0, 1, 2, 3]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3, 0])
+      iex> ForthEvaluator.Stack.divide(stack)
+      {:error, "Division by zero."}
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3])
+      iex> ForthEvaluator.Stack.divide(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.divide(stack)
+      {:error, "There are not enough elements in the stack."} 
+
+  """
+  def divide(stack) do
+    elements = Agent.get(stack, &Function.identity/1)
+
+    # Peek at the 2nd element.
+    case Enum.at(elements, 1, :invalid_index) do
+      :invalid_index -> failure_response(:double)
+      0 -> {:error, "Division by zero."}
+      _ -> binary_operation(stack, &//2)
+    end
+  end
+
+  @spec duplicate(stack :: pid()) :: op_result
+  @doc """
+  Duplicates the top element in the stack, placing a copy of it at the top.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If the stack is empty, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([99, 1, 2])
+      iex> ForthEvaluator.Stack.duplicate(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [99, 99, 1, 2]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3])
+      iex> ForthEvaluator.Stack.duplicate(stack)
+      {:ok, ""} 
+      iex> Agent.get(stack, &Function.identity/1)
+      [3, 3]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.duplicate(stack)
+      {:error, "The stack is empty."} 
+
+  """
+  def duplicate(stack) do
+    Agent.get_and_update(stack, fn state ->
+      case state do
+        [head | tail] -> success([head, head | tail])
+        _ -> failure(state, :single)
+      end
+    end)
+  end
+
+  @spec drop(stack :: pid()) :: op_result
+  @doc """
+  Removes the top of the stack.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If the stack is empty, returns an error and its description.
+
+  This function is equivalent to `pop` without its return value.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1, 2])
+      iex> ForthEvaluator.Stack.drop(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [2]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([4, 5, 6])
+      iex> ForthEvaluator.Stack.drop(stack)
+      {:ok, ""}
+      iex> ForthEvaluator.Stack.drop(stack)
+      {:ok, ""}
+      iex> ForthEvaluator.Stack.drop(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      []
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.pop(stack)
+      {:error, "The stack is empty."}
+
+  """
+  def drop(stack) do
+    case pop(stack) do
+      {:ok, _} -> {:ok, ""}
+      error -> error
+    end
+  end
+
+  @spec swap(stack :: pid()) :: op_result
+  @doc """
+  Swaps the two top elements of the stack.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1, 2])
+      iex> ForthEvaluator.Stack.swap(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [2, 1]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3, 4, 5, 6])
+      iex> ForthEvaluator.Stack.swap(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [4, 3, 5, 6]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3])
+      iex> ForthEvaluator.Stack.swap(stack)
+      {:error, "There are not enough elements in the stack."}
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.swap(stack)
+      {:error, "There are not enough elements in the stack."}
+
+  """
+  def swap(stack) do
+    Agent.get_and_update(stack, fn state ->
+      case state do
+        [x, y | tail] -> success([y, x | tail])
+        _ -> failure(state, :double)
+      end
+    end)
+  end
+
+  @spec over(stack :: pid()) :: op_result
+  @doc """
+  Pushes a copy of the second element to the top of the stack. Essentially pushing the second 
+  element over the first.
+  If successful, returns an empty string (meaning there is no return value for this operation).
+  If there aren't at least 2 elements in the stack, returns an error and its description.
+
+  ## Example
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([1, 2])
+      iex> ForthEvaluator.Stack.over(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [2, 1, 2]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3, 4, 5, 6])
+      iex> ForthEvaluator.Stack.over(stack)
+      {:ok, ""}
+      iex> Agent.get(stack, &Function.identity/1)
+      [4, 3, 4, 5, 6]
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link([3])
+      iex> ForthEvaluator.Stack.over(stack)
+      {:error, "There are not enough elements in the stack."}
+
+      iex> {:ok, stack} = ForthEvaluator.Stack.start_link()
+      iex> ForthEvaluator.Stack.over(stack)
+      {:error, "There are not enough elements in the stack."}
+
+  """
+  def over(stack) do
+    Agent.get_and_update(stack, fn state ->
+      case state do
+        [x, y | tail] -> success([y, x, y | tail])
+        _ -> failure(state, :double)
+      end
+    end)
+  end
+
+  defp binary_operation(stack, fun) do
+    Agent.get_and_update(stack, fn state ->
+      case state do
+        [x, y | tail] ->
+          success([fun.(x, y) | tail])
+
+        _ ->
+          failure(state, :double)
+      end
+    end)
+  end
+
+  defp success(state, result \\ "") do
+    {{:ok, result}, state}
+  end
+
+  defp failure(state, kind) do
+    {failure_response(kind), state}
+  end
+
+  defp failure_response(kind) do
+    error_msg =
+      case kind do
+        :single -> "The stack is empty."
+        :double -> "There are not enough elements in the stack."
+      end
+
+    {:error, error_msg}
+  end
+end

--- a/test/forth_evaluator/dictionary_test.exs
+++ b/test/forth_evaluator/dictionary_test.exs
@@ -1,0 +1,4 @@
+defmodule ForthEvaluator.DictionaryTest do
+  use ExUnit.Case, async: true
+  doctest ForthEvaluator.Dictionary
+end

--- a/test/forth_evaluator/evaluator_test.exs
+++ b/test/forth_evaluator/evaluator_test.exs
@@ -1,0 +1,38 @@
+defmodule ForthEvaluator.EvaluatorTest do
+  use ExUnit.Case, async: true
+
+  alias ForthEvaluator.{Parser, Evaluator, Stack, Dictionary}
+
+  setup do
+    {:ok, stack} = Stack.start_link()
+    {:ok, dictionary} = Dictionary.start_link()
+    [stack: stack, dictionary: dictionary]
+  end
+
+  def run_program(program, context) do
+    {:ok, tokens} = Parser.parse_program(program)
+    Evaluator.evaluate(tokens, context[:stack], context[:dictionary])
+  end
+
+  test "valid program with predefined operations", context do
+    assert run_program("1 2 + 3 * .", context) == "9"
+    assert run_program("1 1 - . 2 4 / .", context) == "0 2.0"
+    assert run_program("2 DUP * DUP . 8 OVER . * .", context) == "4 4 32"
+  end
+
+  test "valid program with word definitions", context do
+    assert run_program(": square DUP * ; 1 3 square . .", context) == "9 1"
+    assert run_program(": double 2 * ; 4 double . 5 double .", context) == "8 10"
+    assert run_program(": half 2 SWAP / ; 8 half . 7 half .", context) == "4.0 3.5"
+  end
+
+  test "raises runtime errors for unknown words", context do
+    assert run_program("1 1 + . example_word 3 3 .", context) ==
+             "2 RuntimeError: Unknown word 'example_word'"
+  end
+
+  test "program stops at runtime errors", context do
+    assert run_program("1 2 3 . . . .", context) == "3 2 1 RuntimeError: The stack is empty."
+    assert run_program("0 2 /", context) == "RuntimeError: Division by zero."
+  end
+end

--- a/test/forth_evaluator/stack_test.exs
+++ b/test/forth_evaluator/stack_test.exs
@@ -1,0 +1,4 @@
+defmodule ForthEvaluator.StackTest do
+  use ExUnit.Case, async: true
+  doctest ForthEvaluator.Stack
+end


### PR DESCRIPTION
> [!WARNING]
> This PR depends on #5 

The purpose of this pull request is to implement the Evaluator module of the program.

The evaluator makes use of a now fully implemented Stack agent, that
handles runtime state, and a Dictionary agent, that stores all program
defined words on runtime.

`ForthEvaluator.Evaluator.evaluate/3` receives a list of tokens (provided by the `Parser` module), a stack and a dictionary pids, and evaluates each operation sequentially. Producing changes to the stack and the dictionary accordingly. Finally, it compiles all the outputs of each operation into one single, space separated, string.

This pull request also includes an update to the Parsing program.
It introduces the concept of `dictionary_op`s which are used in a similar way as the `stack_op`s by the evaluator. Reducing the complexity of this module.